### PR TITLE
Changed output_file() to read many bytes at a time

### DIFF
--- a/cat.c
+++ b/cat.c
@@ -25,10 +25,15 @@ int main(int argc, char **argv) {
 
 }
 
+#define BUFFER_SZ 1024
+
 void output_file(FILE *in, FILE *out) {
-  int chr;
-  while ( (chr = getc(in) ) != EOF ) {
-    putc(chr, out);
+  static const size_t BUFFER_SZ = 1024;
+  static char buffer[BUFFER_SZ];
+  
+  size_t sz; // Number of bytes read by fread()
+  while ((sz = fread(buffer, 1, BUFFER_SZ, in)) != 0) {
+    fwrite(buffer, 1, BUFFER_SZ, out);
   }
 }
 

--- a/cat.c
+++ b/cat.c
@@ -25,8 +25,6 @@ int main(int argc, char **argv) {
 
 }
 
-#define BUFFER_SZ 1024
-
 void output_file(FILE *in, FILE *out) {
   static const size_t BUFFER_SZ = 1024;
   static char buffer[BUFFER_SZ];


### PR DESCRIPTION
Instead of using getc() and putc(), output_file() now reads using a buffer (of 1024 bytes, right now).
